### PR TITLE
Update DocsExample to latest EventStore.Client NuGet package and fix typo.

### DIFF
--- a/DocsExample/DocsExample.csproj
+++ b/DocsExample/DocsExample.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>docs_example_csharp</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="EventStore.Client" Version="4.1.1" />
+    <PackageReference Include="EventStore.Client" Version="5.0.2" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 </Project>

--- a/DocsExample/Program.cs
+++ b/DocsExample/Program.cs
@@ -190,7 +190,7 @@ namespace DocsExample
                     }).outputState()";
 
             projection.UpdateQueryAsync("xbox-one-s-counter", countItemsProjectionUpdate, adminCredentials).Wait();
-            projection.ResetAsynsc("xbox-one-s-counter", countItemsProjectionUpdate, adminCredentials).Wait();
+            projection.ResetAsync("xbox-one-s-counter", adminCredentials).Wait();
 
             var readEvents = conn.ReadStreamEventsForwardAsync("$projections-xbox-one-s-counter-result", 0, 10, true)
                 .Result;


### PR DESCRIPTION
Updated the DocsExample project to the currently latest version of the EventStore.Client NuGet package to ensure .NET Core 2.x support and also fixed a typo in the DocsExample code that misspelt the `ResetAsync` method name.